### PR TITLE
Explicitly log note when running the gem on ActionCable 7.1+

### DIFF
--- a/lib/action-cable-redis-backport.rb
+++ b/lib/action-cable-redis-backport.rb
@@ -2,7 +2,11 @@
 
 require "action_cable"
 
-return if ActionCable::VERSION::MAJOR >= 7 && ActionCable::VERSION::MINOR >= 1
+if ActionCable::VERSION::MAJOR >= 7 && ActionCable::VERSION::MINOR >= 1
+  puts "[action-cable-redis-backport] NOTE: You are running the action-cable-redis-backport gem on Rails 7.1+. This backport is not needed on versions after ActionCable 7.1.0. You can now safely remove this gem from your Gemfile."
+
+  return
+end
 
 require "action_cable/subscription_adapter/redis"
 


### PR DESCRIPTION
Hey there 👋🏼 

I feel like it makes sense that we actively inform users and make them aware that they are running this backport on ActionCable 7.1+ and that they don't need it anymore.

Feel free to tweak the message or pull request as needed! 🙌🏼 